### PR TITLE
Fix query start date lookback

### DIFF
--- a/PulmoPulse/Localizable.xcstrings
+++ b/PulmoPulse/Localizable.xcstrings
@@ -214,13 +214,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Body weight querying"
+            "value" : "Querying body weight starting from %@"
           }
         },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Zapytanie o masę ciała"
+            "value" : "Wyszukiwanie danych masy ciała od %@"
           }
         }
       }
@@ -1405,13 +1405,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Oxygen querying"
+            "value" : "Querying oxygen saturation starting from %@"
           }
         },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Zapytanie o tlen"
+            "value" : "Wyszukiwanie saturacji od %@"
           }
         }
       }
@@ -1566,13 +1566,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Respiratory data querying"
+            "value" : "Querying respiratory rate starting from %@"
           }
         },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Wykonywanie zapytań dotyczących danych układu oddechowego"
+            "value" : "Wyszukiwanie częstości oddechów od %@"
           }
         }
       }
@@ -1855,13 +1855,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Steps querying"
+            "value" : "Querying step count starting from %@"
           }
         },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Wykonywanie zapytań dotyczących kroków"
+            "value" : "Wyszukiwanie kroków od %@"
           }
         }
       }

--- a/PulmoPulse/Modules/DataTransfer/Services/DataUploader.swift
+++ b/PulmoPulse/Modules/DataTransfer/Services/DataUploader.swift
@@ -118,22 +118,22 @@ class DataUploader {
 
         let uploader = uploaders[uploaderIndex]
 
-        HealthDataManager.shared.getEffectiveUploadStartDate(for: uploader.typeIdentifier, userId: userId) { startDate in
-            uploader.uploadSince(
-                startDate: startDate,
+        let startDate = HealthDataManager.shared.getOverrideStartDate()
+
+        uploader.uploadSince(
+            startDate: startDate,
+            userId: userId,
+            progressHandler: progressHandler,
+            logHandler: logHandler
+        ) { uploadedCount in
+            uploadNext(
+                uploaderIndex: uploaderIndex + 1,
+                totalUploaded: totalUploaded + uploadedCount,
                 userId: userId,
                 progressHandler: progressHandler,
-                logHandler: logHandler
-            ) { uploadedCount in
-                uploadNext(
-                    uploaderIndex: uploaderIndex + 1,
-                    totalUploaded: totalUploaded + uploadedCount,
-                    userId: userId,
-                    progressHandler: progressHandler,
-                    logHandler: logHandler,
-                    completion: completion
-                )
-            }
+                logHandler: logHandler,
+                completion: completion
+            )
         }
     }
 }

--- a/PulmoPulse/Modules/HealthData/HealthKitUpload/ActivityUploader.swift
+++ b/PulmoPulse/Modules/HealthData/HealthKitUpload/ActivityUploader.swift
@@ -19,7 +19,7 @@ struct ActivityUploader: HealthDataUploader {
     var typeIdentifier: String { "activity" }
 
     func fetchSamples(
-        since _: Date,
+        since startDate: Date,
         log: @escaping (String) -> Void,
         completion: @escaping ([HKQuantitySample]) -> Void
     ) {
@@ -30,11 +30,10 @@ struct ActivityUploader: HealthDataUploader {
         }
 
         let calendar = Calendar.current
-        let fallbackStart = calendar.date(byAdding: .day, value: -7, to: Date())!
-        let startDate = calendar.startOfDay(for: manager?.getOverrideStartDate() ?? fallbackStart)
+        let start = calendar.startOfDay(for: startDate)
         let endDate = Date()
 
-        let predicate = HKQuery.predicateForSamples(withStart: startDate, end: endDate, options: [])
+        let predicate = HKQuery.predicateForSamples(withStart: start, end: endDate, options: [])
         let sortDescriptor = NSSortDescriptor(key: HKSampleSortIdentifierStartDate, ascending: true)
 
         let query = HKSampleQuery(
@@ -53,7 +52,7 @@ struct ActivityUploader: HealthDataUploader {
             completion(samples)
         }
 
-        log("🔥 " + String(format: NSLocalizedString("activity_querying_from", comment: ""), startDate.formatted(date: .abbreviated, time: .omitted)))
+        log("🔥 " + String(format: NSLocalizedString("activity_querying_from", comment: ""), start.formatted(date: .abbreviated, time: .omitted)))
         healthStore.execute(query)
     }
 

--- a/PulmoPulse/Modules/HealthData/HealthKitUpload/BodyWeightUploader.swift
+++ b/PulmoPulse/Modules/HealthData/HealthKitUpload/BodyWeightUploader.swift
@@ -19,7 +19,7 @@ struct BodyWeightUploader: HealthDataUploader {
     var typeIdentifier: String { "bodyWeight" }
 
     func fetchSamples(
-        since _: Date,
+        since startDate: Date,
         log: @escaping (String) -> Void,
         completion: @escaping ([HKQuantitySample]) -> Void
     ) {
@@ -30,11 +30,10 @@ struct BodyWeightUploader: HealthDataUploader {
         }
 
         let calendar = Calendar.current
-        let fallback = calendar.date(byAdding: .day, value: -7, to: Date())!
-        let startDate = calendar.startOfDay(for: manager?.getOverrideStartDate() ?? fallback)
+        let start = calendar.startOfDay(for: startDate)
         let endDate = Date()
 
-        let predicate = HKQuery.predicateForSamples(withStart: startDate, end: endDate, options: [])
+        let predicate = HKQuery.predicateForSamples(withStart: start, end: endDate, options: [])
         let sort = NSSortDescriptor(key: HKSampleSortIdentifierStartDate, ascending: true)
 
         let query = HKSampleQuery(
@@ -53,7 +52,7 @@ struct BodyWeightUploader: HealthDataUploader {
             completion(samples)
         }
 
-        log("📥 " + NSLocalizedString("body_weight_querying", comment: ""))
+        log("📥 " + String(format: NSLocalizedString("body_weight_querying", comment: ""), start.formatted()))
         healthStore.execute(query)
     }
 

--- a/PulmoPulse/Modules/HealthData/HealthKitUpload/HeartRateUploader.swift
+++ b/PulmoPulse/Modules/HealthData/HealthKitUpload/HeartRateUploader.swift
@@ -19,7 +19,7 @@ struct HeartRateUploader: HealthDataUploader {
     var typeIdentifier: String { "heartRate" }
 
     func fetchSamples(
-        since _: Date,
+        since startDate: Date,
         log: @escaping (String) -> Void,
         completion: @escaping ([HKQuantitySample]) -> Void
     ) {
@@ -29,8 +29,8 @@ struct HeartRateUploader: HealthDataUploader {
             return
         }
 
-        let startDate = Calendar.current.startOfDay(for: manager?.getOverrideStartDate() ?? Date(timeIntervalSinceNow: -7 * 86400))
-        let predicate = HKQuery.predicateForSamples(withStart: startDate, end: Date(), options: [])
+        let start = Calendar.current.startOfDay(for: startDate)
+        let predicate = HKQuery.predicateForSamples(withStart: start, end: Date(), options: [])
         let sort = NSSortDescriptor(key: HKSampleSortIdentifierStartDate, ascending: true)
 
         let query = HKSampleQuery(
@@ -49,7 +49,7 @@ struct HeartRateUploader: HealthDataUploader {
             completion(samples)
         }
 
-        log("💓 " + String(format: NSLocalizedString("heart_rate_querying", comment: ""), startDate.formatted()))
+        log("💓 " + String(format: NSLocalizedString("heart_rate_querying", comment: ""), start.formatted()))
         healthStore.execute(query)
     }
 

--- a/PulmoPulse/Modules/HealthData/HealthKitUpload/OxygenSaturationUploader.swift
+++ b/PulmoPulse/Modules/HealthData/HealthKitUpload/OxygenSaturationUploader.swift
@@ -27,7 +27,7 @@ class OxygenSaturationUploader: HealthDataUploader {
     }
 
     func fetchSamples(
-        since _: Date,
+        since startDate: Date,
         log: @escaping (String) -> Void,
         completion: @escaping ([HKQuantitySample]) -> Void
     ) {
@@ -38,11 +38,10 @@ class OxygenSaturationUploader: HealthDataUploader {
         }
 
         let calendar = Calendar.current
-        let fallback = calendar.date(byAdding: .day, value: -7, to: Date())!
-        let startDate = calendar.startOfDay(for: manager?.getOverrideStartDate() ?? fallback)
+        let start = calendar.startOfDay(for: startDate)
         let endDate = Date()
 
-        let predicate = HKQuery.predicateForSamples(withStart: startDate, end: endDate, options: [])
+        let predicate = HKQuery.predicateForSamples(withStart: start, end: endDate, options: [])
         let sort = NSSortDescriptor(key: HKSampleSortIdentifierStartDate, ascending: true)
 
         let query = HKSampleQuery(
@@ -61,7 +60,7 @@ class OxygenSaturationUploader: HealthDataUploader {
             completion(samples)
         }
 
-        log("🫁 " + NSLocalizedString("oxygen_querying", comment: ""))
+        log("🫁 " + String(format: NSLocalizedString("oxygen_querying", comment: ""), start.formatted()))
         healthStore.execute(query)
     }
 

--- a/PulmoPulse/Modules/HealthData/HealthKitUpload/RespiratoryRateUploader.swift
+++ b/PulmoPulse/Modules/HealthData/HealthKitUpload/RespiratoryRateUploader.swift
@@ -20,7 +20,7 @@ struct RespiratoryRateUploader: HealthDataUploader {
     var typeIdentifier: String { "respiratoryRate" }
 
     func fetchSamples(
-        since _: Date,
+        since startDate: Date,
         log: @escaping (String) -> Void,
         completion: @escaping ([HKQuantitySample]) -> Void
     ) {
@@ -31,11 +31,10 @@ struct RespiratoryRateUploader: HealthDataUploader {
         }
 
         let calendar = Calendar.current
-        let fallback = calendar.date(byAdding: .day, value: -7, to: Date())!
-        let startDate = calendar.startOfDay(for: manager?.getOverrideStartDate() ?? fallback)
+        let start = calendar.startOfDay(for: startDate)
         let endDate = Date()
 
-        let predicate = HKQuery.predicateForSamples(withStart: startDate, end: endDate, options: [])
+        let predicate = HKQuery.predicateForSamples(withStart: start, end: endDate, options: [])
         let sort = NSSortDescriptor(key: HKSampleSortIdentifierStartDate, ascending: true)
 
         let query = HKSampleQuery(
@@ -54,7 +53,7 @@ struct RespiratoryRateUploader: HealthDataUploader {
             completion(samples)
         }
 
-        log("🫁 " + NSLocalizedString("respiratory_querying", comment: ""))
+        log("🫁 " + String(format: NSLocalizedString("respiratory_querying", comment: ""), start.formatted()))
         healthStore.execute(query)
     }
 

--- a/PulmoPulse/Modules/HealthData/HealthKitUpload/StepsUploader.swift
+++ b/PulmoPulse/Modules/HealthData/HealthKitUpload/StepsUploader.swift
@@ -21,7 +21,7 @@ struct StepsUploader: HealthDataUploader {
     var typeIdentifier: String { "steps" }
 
     func fetchSamples(
-        since _: Date,
+        since startDate: Date,
         log: @escaping (String) -> Void,
         completion: @escaping ([HKQuantitySample]) -> Void
     ) {
@@ -32,11 +32,10 @@ struct StepsUploader: HealthDataUploader {
         }
 
         let calendar = Calendar.current
-        let fallback = calendar.date(byAdding: .day, value: -7, to: Date())!
-        let startDate = calendar.startOfDay(for: manager?.getOverrideStartDate() ?? fallback)
+        let start = calendar.startOfDay(for: startDate)
         let endDate = Date()
 
-        let predicate = HKQuery.predicateForSamples(withStart: startDate, end: endDate, options: [])
+        let predicate = HKQuery.predicateForSamples(withStart: start, end: endDate, options: [])
         let sort = NSSortDescriptor(key: HKSampleSortIdentifierStartDate, ascending: true)
 
         let query = HKSampleQuery(
@@ -55,7 +54,7 @@ struct StepsUploader: HealthDataUploader {
             completion(samples)
         }
 
-        log("👟 " + NSLocalizedString("steps_querying", comment: ""))
+        log("👟 " + String(format: NSLocalizedString("steps_querying", comment: ""), start.formatted()))
         healthStore.execute(query)
     }
 


### PR DESCRIPTION
## Summary
- use `getOverrideStartDate()` when uploading health data to always apply the configured look-back window

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_68662300aa38832db7094f2eb7fba5b3